### PR TITLE
fix: adjust vide config to deploy correctly on gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "gh-pages -d dist",
     "lint": "eslint -c eslint.config.js --cache .",
     "lint:fix": "npm run lint -- --no-cache --fix",
     "prettier": "prettier --check --cache --no-error-on-unmatched-pattern '**/*.md' '**/*.yml' '**/*.json' '**/*.html' '**/*.css' '**/*.scss' '**/*.sass' '**/*.less'",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
+  base: '/klo-meister/',
   build: {
     outDir: "dist",
   },

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
-  base: '/klo-meister/',
+  base: "/klo-meister/",
   build: {
     outDir: "dist",
   },


### PR DESCRIPTION
This pull request includes changes to the build and deployment configuration for the project. The most important changes are:

Build and deployment configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L20-R20): Changed the `deploy` script to use the `dist` directory instead of the `build` directory.
* [`vite.config.mjs`](diffhunk://#diff-2e657ae9f09c132c79d6427283907e07526b1bc7f175dab3cf6bbe3da8334cbfR6): Added a `base` property with the value `/klo-meister/` to the Vite configuration.